### PR TITLE
Fix scrolling behaviour when doubleScroll is used

### DIFF
--- a/lib/nested_scroll_controller.dart
+++ b/lib/nested_scroll_controller.dart
@@ -445,7 +445,7 @@ class _NestedAutoScroller {
         print("Outer jumped to: $_scrollControllerOffset");
 
         if (_innerScrollControllerOffset > 0) {
-          _endController.jumpTo(_innerScrollControllerOffset);
+          _startController.jumpTo(_innerScrollControllerOffset);
           print("Inner jumped to: $_innerScrollControllerOffset");
         }
 


### PR DESCRIPTION
Ahoy!

First, I just want to say thanks for all your hard work on this! It has been massively helpful. I've got a small fix involving `doubleScroll` :

  * `doubleScroll` was performing the `jumpTo` on the outer controller
      twice because the wrong variable was used. Renamed to correct
      variable to fix (now jumps to inner scroll controller as well).

In the app I've got, scrolling down (increasing the offset) worked beautifully _but_ whenever I would scroll up decreasing the offset of the `innerScrollController`, it would be immediately reset to `0`. It took me a bit of digging but eventually I logged the `position` of the `_endController` and noticed it was literally the same _instance_ as the "outer" scroll controller used above it. Changing it to the `_startController` (which points to the `innerScrollerController`) fixed the issue and the offset is now correctly set 🎊 🎉 .

Let me know if there's anything I can change in the PR. Thanks for your time!